### PR TITLE
Add pre-flight job queue check to prevent unnecessary file uploads

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2425,8 +2425,22 @@
         }
       })
 
-      function uploadFile() {
+      async function uploadFile() {
         if (!selectedFile) return
+
+        // PRE-FLIGHT CHECK: Verify user doesn't have a job queued
+        try {
+          const checkResponse = await fetch('/api/check-job-status')
+          const checkData = await checkResponse.json()
+
+          if (checkResponse.status === 400 || checkData.has_job) {
+            showError(checkData.error)
+            return  // Stop before uploading
+          }
+        } catch (e) {
+          console.error('Job status check failed:', e)
+          // Continue with upload if check fails (fail-open)
+        }
 
         const formData = new FormData()
         formData.append("file", selectedFile)


### PR DESCRIPTION
### Summary

- Adds a lightweight GET /api/check-job-status endpoint that checks if a user has existing jobs before file upload begins
- Updates frontend uploadFile() function to call the pre-flight check before starting file transfer
- Shows error message immediately without uploading the file, saving bandwidth and improving UX
- Keeps existing server-side validation as a security backup
- Implements graceful degradation: if pre-flight check fails, upload continues and server-side validation catches it

### Problem Solved
- Previously, users saw a progress bar during file upload, only to receive an error message after the entire file was transferred. This wasted bandwidth and time, especially for large files.

### Changes
**Backend (app.py:1523-1550)**

- New endpoint checks user_jobs dictionary and transcoding queues
- Returns appropriate error messages in Hebrew matching existing validation
- Minimal overhead: ~20 lines, no disk I/O

**Frontend (templates/index.html:2431-2443)**

- Pre-flight fetch request before file upload starts
- Async/await pattern for clean error handling
- Fail-open design for reliability

**Test Plan**
- [ ] Test upload with no existing jobs - should proceed normally
- [ ] Test upload with existing transcription job queued - should show error immediately without progress bar
- [ ] Test upload with existing transcoding job running - should show error immediately
- [ ] Test behavior if pre-flight check endpoint is down (should fall back to server-side validation)
- [ ] Verify error messages are in Hebrew and match existing UX
- [ ] Test with large files to confirm bandwidth savings