### PR TITLE
Fix: RunPod token not sent during file upload

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2431,8 +2431,8 @@
         const formData = new FormData()
         formData.append("file", selectedFile)
 
-        // Add RunPod credentials if available
-        const token = getCookie("runpod_token")
+        // Add RunPod credentials if available (from input field OR cookie)
+        const token = runpodTokenInput.value.trim() || getCookie("runpod_token")
         if (token) {
           formData.append("runpod_token", token)
         }


### PR DESCRIPTION
## Summary
Fixes a bug where private RunPod users were incorrectly limited to 300MB instead of 3GB file uploads.

## Problem
The upload function only read the RunPod token from cookies, which required users to click "Check Balance" first. If users entered their token but uploaded directly, the token wasn't sent to the backend, causing them to be treated as regular users with the 300MB limit.

## Solution
Modified the upload function to read the token from the input field first, then fall back to the cookie value. This ensures the token is always sent if present.

## Changes
- **File:** `templates/index.html:2435`
- **Change:** `const token = runpodTokenInput.value.trim() || getCookie("runpod_token")`

## Test plan
- [ ] Enter RunPod token in the input field
- [ ] Upload a file >300MB without clicking "Check Balance"
- [ ] Verify file upload succeeds with 3GB limit