### PR TITLE
Replace delete icon from X to trash bin (trash-2)

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3323,7 +3323,7 @@
           const deleteBtn = document.createElement('button')
           deleteBtn.className = 'file-item-delete-btn'
           deleteBtn.title = (window.I18N ? window.I18N.t('deleteFile') : 'מחק קובץ')
-          deleteBtn.innerHTML = '<i data-lucide="x"></i>'
+          deleteBtn.innerHTML = '<i data-lucide="trash-2"></i>'
           deleteBtn.onclick = (e) => {
             e.stopPropagation()
             confirmDeleteFile(entry.results_id, entry.source_filename)


### PR DESCRIPTION
- Changed delete button icon from 'x' to 'trash-2' for better UX
- Trash bin icon is more intuitive and universally recognized as delete action
- Uses existing Lucide icon library