### PR TITLE
Add queue full error tracking and statistics

### DIFF
--- a/app.py
+++ b/app.py
@@ -551,6 +551,9 @@ stats_transcoding_total_duration_seconds = 0.0
 # Quota statistics
 stats_quota_denied = 0
 
+# Queue full statistics
+stats_queue_full_errors = 0
+
 # Dictionary to keep track of user's active jobs
 user_jobs = {}
 
@@ -837,7 +840,7 @@ async def calculate_queue_time(queue_to_use, running_jobs, exclude_last=False):
 async def queue_job(job_id, user_email, filename, duration, runpod_token="", language="he", refresh_token: Optional[str] = None, save_audio: bool = False):
     # Try to add the job to the queue
     log_message(f"{user_email}: Queuing job {job_id}...")
-    global stats_quota_denied
+    global stats_quota_denied, stats_queue_full_errors
 
     def build_error(error_key, *, status_code=400, i18n_vars=None):
         payload = {"error": error_key, "i18n_key": error_key, "status_code": status_code}
@@ -949,6 +952,8 @@ async def queue_job(job_id, user_email, filename, duration, runpod_token="", lan
                 "time_ahead_seconds": int(time_ahead_seconds),
             }
     except queue.Full:
+        async with stats_lock:
+            stats_queue_full_errors += 1
         capture_event(job_id, "job-queue-failed", {"queue-depth": queue_depth, "job-type": job_type})
 
         log_message(f"{user_email}: Job queuing failed: {job_id}")
@@ -2253,7 +2258,8 @@ async def get_stats(request: Request):
             "transcoding": transcoding_stats,
             "errors": {
                 "google_drive": drive_errors,
-                "quota_denied": stats_quota_denied
+                "quota_denied": stats_quota_denied,
+                "queue_full": stats_queue_full_errors
             }
         }
 
@@ -2506,6 +2512,8 @@ async def queue_transcoding_job(
             queue_depth = transcoding_queue.qsize()
             transcoding_queue.put_nowait(transcoding_job)
     except queue.Full:
+        async with stats_lock:
+            stats_queue_full_errors += 1
         cleanup_temp_file(job_id)
         return None
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -2377,6 +2377,11 @@
                     <span class="stats-row-label">Transcription Quota Exceeded:</span>
                     <span class="stats-row-value" id="quota-denied-errors">-</span>
                   </div>
+                  <h4 style="margin: 0; color: var(--text-color); font-size: 0.95rem; text-align: left; margin-top: 1rem;">Queue</h4>
+                  <div class="stats-row">
+                    <span class="stats-row-label">Queue Full Errors:</span>
+                    <span class="stats-row-value" id="queue-full-errors">-</span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -8523,6 +8528,7 @@
           document.getElementById('gdrive-rename-errors').textContent = driveErrors.rename ?? '-'
           document.getElementById('gdrive-delete-errors').textContent = driveErrors.delete ?? '-'
           document.getElementById('quota-denied-errors').textContent = data.errors?.quota_denied ?? '-'
+          document.getElementById('queue-full-errors').textContent = data.errors?.queue_full ?? '-'
 
           // Show content, hide loading
           statsLoading.style.display = 'none'


### PR DESCRIPTION
## Summary
This PR adds tracking and monitoring of queue full errors that occur when jobs cannot be added to the processing queue due to capacity constraints.

## Key Changes
- **New statistics counter**: Added `stats_queue_full_errors` global variable to track the number of times the queue becomes full
- **Error tracking in queue operations**: Implemented atomic increment of the queue full error counter in both `queue_job()` and `queue_transcoding_job()` functions when `queue.Full` exceptions are caught
- **Thread-safe updates**: Used `stats_lock` to ensure thread-safe increments of the counter
- **API endpoint enhancement**: Updated the `/stats` endpoint to include queue full errors in the response under `errors.queue_full`
- **UI display**: Added a new "Queue" section in the statistics dashboard to display queue full errors to users

## Implementation Details
- The counter is incremented atomically using the existing `stats_lock` to prevent race conditions
- Queue full errors are now captured alongside other error metrics (Google Drive errors, quota denied errors)
- The frontend displays the queue full error count in the statistics panel, matching the existing error display pattern

https://claude.ai/code/session_018sS8ra5pwHrBFRqFTHk1Kk